### PR TITLE
Correctly handle null values in Entries, Drafts, Results and Draft Results resources

### DIFF
--- a/draft.go
+++ b/draft.go
@@ -80,11 +80,8 @@ func entryToDraftFullMedia(entry *model.Entry) *app.ComJossemargtSaoDraftFull {
 		ContestSlug: entry.ContestSlug,
 		TaskID:      entry.TaskID,
 		TaskSlug:    entry.TaskSlug,
+		Language:    entry.Language,
 		Href:        fmt.Sprintf("%s%d", app.DraftHref(), entry.ID),
-	}
-
-	if entry.Language != nil {
-		media.Language = *entry.Language
 	}
 
 	links := new(app.ComJossemargtSaoDraftLinks)

--- a/draftresult.go
+++ b/draftresult.go
@@ -107,18 +107,15 @@ func draftresultModelToMediaFull(result *model.DraftResult) *app.ComJossemargtSa
 			WallClockTime: float64(result.Execution.WallClockTime),
 			Output:        string(result.Output),
 		},
-	}
-
-	if result.Compilation.Status != nil {
-		media.Compilation = &app.CompilationResult{
-			Status:        *result.Compilation.Status,
+		Compilation: &app.CompilationResult{
+			Status:        result.Compilation.Status,
 			Tries:         result.Compilation.Tries,
 			Stdout:        result.Compilation.Stdout,
 			Stderr:        result.Compilation.Stderr,
 			Time:          float64(result.Compilation.Time),
 			WallClockTime: float64(result.Compilation.WallClockTime),
 			Memory:        result.Compilation.Memory,
-		}
+		},
 	}
 
 	if !result.Evaluation.Done {

--- a/draftresult_test.go
+++ b/draftresult_test.go
@@ -17,8 +17,6 @@ import (
 )
 
 func TestDraftResultController_Get(t *testing.T) {
-	okString := "ok"
-
 	scenarios := []struct {
 		name             string
 		mockRepo         storage.DraftResultRepository
@@ -32,7 +30,7 @@ func TestDraftResultController_Get(t *testing.T) {
 					EntryID:   5,
 					DatasetID: 7,
 					Compilation: model.Compilation{
-						Status:        &okString,
+						Status:        "ok",
 						Tries:         1,
 						Memory:        125,
 						WallClockTime: 2,
@@ -44,7 +42,7 @@ func TestDraftResultController_Get(t *testing.T) {
 			expectedResource: &app.ComJossemargtSaoDraftResultFull{
 				ID: "5-7",
 				Compilation: &app.CompilationResult{
-					Status:        okString,
+					Status:        "ok",
 					Tries:         1,
 					Memory:        125,
 					WallClockTime: 2,

--- a/entry.go
+++ b/entry.go
@@ -75,15 +75,13 @@ func (c *EntryController) Show(ctx *app.ShowEntryContext) error {
 }
 
 func entryModelToMedia(entry *model.Entry) *app.ComJossemargtSaoEntry {
-	media := app.ComJossemargtSaoEntry{
+	return &app.ComJossemargtSaoEntry{
 		ID:          entry.ID,
 		ContestSlug: entry.ContestSlug,
 		TaskSlug:    entry.TaskSlug,
 		Token:       entry.Token,
 		Href:        fmt.Sprintf("%s%d", app.EntryHref(), entry.ID),
 	}
-
-	return &media
 }
 
 func entryModelToMediaFull(entry *model.Entry) *app.ComJossemargtSaoEntryFull {
@@ -94,11 +92,8 @@ func entryModelToMediaFull(entry *model.Entry) *app.ComJossemargtSaoEntryFull {
 		TaskID:      entry.TaskID,
 		TaskSlug:    entry.TaskSlug,
 		Token:       entry.Token,
+		Language:    entry.Language,
 		Href:        fmt.Sprintf("%s%d", app.EntryHref(), entry.ID),
-	}
-
-	if entry.Language != nil {
-		media.Language = *entry.Language
 	}
 
 	links := new(app.ComJossemargtSaoEntryLinks)

--- a/entry_test.go
+++ b/entry_test.go
@@ -35,7 +35,7 @@ func TestEntryController_Get(t *testing.T) {
 					TaskSlug:    "batch_test",
 					ContestSlug: "con_test",
 					Token:       true,
-					Language:    &defLan,
+					Language:    defLan,
 				},
 			},
 			expectedResource: &app.ComJossemargtSaoEntryFull{
@@ -64,6 +64,7 @@ func TestEntryController_Get(t *testing.T) {
 					TaskSlug:    "batch_test",
 					ContestSlug: "con_test",
 					DatasetID:   7,
+					Language:    "none",
 				},
 			},
 			expectedResource: &app.ComJossemargtSaoEntryFull{
@@ -73,6 +74,7 @@ func TestEntryController_Get(t *testing.T) {
 				ContestSlug: "con_test",
 				TaskSlug:    "batch_test",
 				Token:       false,
+				Language:    "none",
 				Href:        fmt.Sprintf("%s%d", app.EntryHref(), 5),
 				Links: &app.ComJossemargtSaoEntryLinks{
 					Result: &app.ComJossemargtSaoResultLink{

--- a/model/entry.go
+++ b/model/entry.go
@@ -4,13 +4,13 @@ import "fmt"
 
 type Entry struct {
 	ID          int
-	ContestID   int     `db:"contest_id"`
-	ContestSlug string  `db:"contest_slug"`
-	TaskID      int     `db:"task_id"`
-	TaskSlug    string  `db:"task_slug"`
-	DatasetID   int     `db:"result_prtl_id"`
-	Language    *string `db:"language"`
-	Token       bool    `db:"token"`
+	ContestID   int
+	ContestSlug string
+	TaskID      int
+	TaskSlug    string
+	DatasetID   int
+	Language    string
+	Token       bool
 }
 
 func (e Entry) ResultID() string {

--- a/model/result.go
+++ b/model/result.go
@@ -1,44 +1,44 @@
 package model
 
 type Result struct {
-	DatasetID int `db:"dataset_id"`
-	EntryID   int `db:"entry_id"`
+	DatasetID int
+	EntryID   int
 	Compilation
 	Evaluation
 	Scoring
 }
 
 type DraftResult struct {
-	DatasetID int `db:"dataset_id"`
-	EntryID   int `db:"entry_id"`
+	DatasetID int
+	EntryID   int
 	Compilation
 	Evaluation
 	Execution
 }
 
 type Compilation struct {
-	Status        *string `db:"compilation_status"`
-	Tries         int     `db:"compilation_tries"`
-	Stdout        string  `db:"compilation_stdout"`
-	Stderr        string  `db:"compilation_stderr"`
-	Time          float32 `db:"compilation_time"`
-	WallClockTime float32 `db:"compilation_wall_clock_time"`
-	Memory        int     `db:"compilation_memory"`
+	Status        string
+	Tries         int
+	Stdout        string
+	Stderr        string
+	Time          float64
+	WallClockTime float64
+	Memory        int
 }
 
 type Evaluation struct {
-	Done  bool `db:"evaluation_done"`
-	Tries int  `db:"evaluation_tries"`
+	Done  bool
+	Tries int
 }
 
 type Scoring struct {
-	TaskScore    float32 `db:"score"`
-	ContestScore float32 `db:"public_score"`
+	TaskScore    float64
+	ContestScore float64
 }
 
 type Execution struct {
-	Time          float32 `db:"execution_time"`
-	WallClockTime float32 `db:"execution_wall_clock_time"`
-	Memory        int     `db:"execution_memory"`
-	Output        []byte  `db:"output_data"`
+	Time          float64
+	WallClockTime float64
+	Memory        int
+	Output        []byte
 }

--- a/result.go
+++ b/result.go
@@ -104,13 +104,12 @@ func resultModelToMedia(result *model.Result, view string) *app.ComJossemargtSao
 			TaskValue:    float64(result.Scoring.TaskScore),
 		},
 		Evaluation: &app.EvaluationResult{
-			Tries: result.Evaluation.Tries,
+			Status: "ok",
+			Tries:  result.Evaluation.Tries,
 		},
 	}
 
-	if result.Evaluation.Done {
-		media.Evaluation.Status = "ok"
-	} else {
+	if !result.Evaluation.Done {
 		media.Evaluation.Status = "unprocessed"
 	}
 
@@ -127,29 +126,25 @@ func resultModelToMediaFull(result *model.Result) *app.ComJossemargtSaoResultFul
 		ID:   id,
 		Href: fmt.Sprintf("%s%s", app.ResultHref(), id),
 		Evaluation: &app.EvaluationResult{
-			Tries: result.Evaluation.Tries,
+			Status: "ok",
+			Tries:  result.Evaluation.Tries,
 		},
 		Score: &app.ScoreResult{
 			ContestValue: float64(result.Scoring.ContestScore),
 			TaskValue:    float64(result.Scoring.TaskScore),
 		},
-	}
-
-	if result.Compilation.Status != nil {
-		media.Compilation = &app.CompilationResult{
-			Status:        *result.Compilation.Status,
+		Compilation: &app.CompilationResult{
+			Status:        result.Compilation.Status,
 			Tries:         result.Compilation.Tries,
 			Stdout:        result.Compilation.Stdout,
 			Stderr:        result.Compilation.Stderr,
 			Time:          float64(result.Compilation.Time),
 			WallClockTime: float64(result.Compilation.WallClockTime),
 			Memory:        result.Compilation.Memory,
-		}
+		},
 	}
 
-	if result.Evaluation.Done {
-		media.Evaluation.Status = "ok"
-	} else {
+	if !result.Evaluation.Done {
 		media.Evaluation.Status = "unprocessed"
 	}
 

--- a/result_test.go
+++ b/result_test.go
@@ -17,8 +17,6 @@ import (
 )
 
 func TestResultController_Get(t *testing.T) {
-	okString := "ok"
-
 	scenarios := []struct {
 		name             string
 		mockRepo         storage.ResultRepository
@@ -32,7 +30,7 @@ func TestResultController_Get(t *testing.T) {
 					EntryID:   5,
 					DatasetID: 7,
 					Compilation: model.Compilation{
-						Status:        &okString,
+						Status:        "ok",
 						Tries:         1,
 						Memory:        125,
 						WallClockTime: 2,
@@ -44,7 +42,7 @@ func TestResultController_Get(t *testing.T) {
 			expectedResource: &app.ComJossemargtSaoResultFull{
 				ID: "5-7",
 				Compilation: &app.CompilationResult{
-					Status:        okString,
+					Status:        "ok",
 					Tries:         1,
 					Memory:        125,
 					WallClockTime: 2,
@@ -111,8 +109,6 @@ func TestResultController_Get(t *testing.T) {
 }
 
 func TestResultController_Show(t *testing.T) {
-	okString := "ok"
-
 	scenarios := []struct {
 		name             string
 		mockRepo         storage.ResultRepository
@@ -127,7 +123,7 @@ func TestResultController_Show(t *testing.T) {
 						EntryID:   5,
 						DatasetID: 7,
 						Compilation: model.Compilation{
-							Status:        &okString,
+							Status:        "ok",
 							Tries:         1,
 							Memory:        125,
 							WallClockTime: 2,

--- a/storage/entry_test.go
+++ b/storage/entry_test.go
@@ -5,8 +5,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/jossemargt/cms-sao/model"
 )
 
 func TestDefaultEntryRepository_FindByID(t *testing.T) {
@@ -20,7 +18,7 @@ func TestDefaultEntryRepository_FindByID(t *testing.T) {
 			queryer: func() *mockDB {
 				m := new(mockDB)
 				m.fnGet = func(d interface{}, q string, a ...interface{}) error {
-					e := model.Entry{
+					e := sqlEntry{
 						ID:          123,
 						ContestSlug: "con_test",
 						TaskSlug:    "a_task",
@@ -82,8 +80,8 @@ func TestDefaultEntryRepository_FindBy(t *testing.T) {
 			queryerFactory: func(t *testing.T) *mockDB {
 				m := new(mockDB)
 				m.fnQuery = func(d interface{}, q string, a ...interface{}) error {
-					es := []model.Entry{
-						model.Entry{
+					es := []sqlEntry{
+						sqlEntry{
 							ID:          123,
 							ContestSlug: "con_test",
 							TaskSlug:    "a_task",
@@ -112,29 +110,19 @@ func TestDefaultEntryRepository_FindBy(t *testing.T) {
 			queryerFactory: func(t *testing.T) *mockDB {
 				m := new(mockDB)
 				m.fnQuery = func(d interface{}, q string, a ...interface{}) error {
-					es := []model.Entry{
-						model.Entry{
+					es := []sqlEntry{
+						sqlEntry{
 							ID:          123,
 							ContestSlug: "con_test",
 							TaskSlug:    "a_task",
 						},
-						model.Entry{
+						sqlEntry{
 							ID:          124,
 							ContestSlug: "con_test",
 							TaskSlug:    "b_task",
 						},
 					}
 					reflect.ValueOf(d).Elem().Set(reflect.ValueOf(es))
-
-					// Checking query
-					if !strings.Contains(q, "LIMIT 15") {
-						t.Error("Expected LIMIT 15 in query statement")
-					}
-
-					if !strings.Contains(q, "OFFSET 15") {
-						t.Error("Expected OFFSET 15 in query statement")
-					}
-
 					return nil
 				}
 				return m

--- a/storage/entrydraft.go
+++ b/storage/entrydraft.go
@@ -27,7 +27,7 @@ func buildEntryDraftFindByIDQuery() (string, error) {
 		From(fmt.Sprintf("%s AS ut", entryDraftTable)),
 		Join("%s AS tsk ON tsk.id = ut.task_id", taskTable),
 		Join("%s AS cts ON cts.id = tsk.contest_id", contestTable),
-		Join("%s AS utr ON utr.user_test_id = ut.id", entryDraftResultTable),
+		LeftJoin("%s AS utr ON utr.user_test_id = ut.id", entryDraftResultTable),
 		Where("ut.id = $1"),
 	)
 }
@@ -48,7 +48,7 @@ func buildEntryDraftFindQuery(dto EntryDTO) (string, error) {
 		From(fmt.Sprintf("%s AS ut", entryDraftTable)),
 		Join("%s AS tsk ON tsk.id = ut.task_id", taskTable),
 		Join("%s AS cts ON cts.id = tsk.contest_id", contestTable),
-		Join("%s AS utr ON utr.user_test_id = ut.id", entryDraftResultTable),
+		LeftJoin("%s AS utr ON utr.user_test_id = ut.id", entryDraftResultTable),
 		OrderBy(fmt.Sprintf("id %s", dto.Order)),
 		Limit(dto.limit),
 	}

--- a/storage/entrydraft_test.go
+++ b/storage/entrydraft_test.go
@@ -5,8 +5,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/jossemargt/cms-sao/model"
 )
 
 func TestDefaultEntryDraftRepository_FindByID(t *testing.T) {
@@ -20,7 +18,7 @@ func TestDefaultEntryDraftRepository_FindByID(t *testing.T) {
 			queryer: func() *mockDB {
 				m := new(mockDB)
 				m.fnGet = func(d interface{}, q string, a ...interface{}) error {
-					e := model.Entry{
+					e := sqlEntry{
 						ID:          123,
 						ContestSlug: "con_test",
 						TaskSlug:    "a_task",
@@ -82,8 +80,8 @@ func TestDefaultEntryDraftRepository_FindBy(t *testing.T) {
 			queryerFactory: func(t *testing.T) *mockDB {
 				m := new(mockDB)
 				m.fnQuery = func(d interface{}, q string, a ...interface{}) error {
-					es := []model.Entry{
-						model.Entry{
+					es := []sqlEntry{
+						sqlEntry{
 							ID:          123,
 							ContestSlug: "con_test",
 							TaskSlug:    "a_task",
@@ -112,13 +110,13 @@ func TestDefaultEntryDraftRepository_FindBy(t *testing.T) {
 			queryerFactory: func(t *testing.T) *mockDB {
 				m := new(mockDB)
 				m.fnQuery = func(d interface{}, q string, a ...interface{}) error {
-					es := []model.Entry{
-						model.Entry{
+					es := []sqlEntry{
+						sqlEntry{
 							ID:          123,
 							ContestSlug: "con_test",
 							TaskSlug:    "a_task",
 						},
-						model.Entry{
+						sqlEntry{
 							ID:          124,
 							ContestSlug: "con_test",
 							TaskSlug:    "b_task",

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -1,9 +1,14 @@
 package storage
 
-import "database/sql"
+import (
+	"database/sql"
+
+	"github.com/jossemargt/cms-sao/model"
+)
 
 const (
-	cmsLanguageDefault = "none"
+	cmsLanguageDefault          = "none"
+	cmsCompilationStatusDefault = "unprocessed"
 )
 
 type sqlEntry struct {
@@ -15,6 +20,112 @@ type sqlEntry struct {
 	DatasetID   sql.NullInt64  `db:"result_prtl_id"`
 	Language    sqlCMSLanguage `db:"language"`
 	Token       bool           `db:"token"`
+}
+
+func (e sqlEntry) toEntry() model.Entry {
+	return model.Entry{
+		ID:          e.ID,
+		ContestID:   e.ContestID,
+		ContestSlug: e.ContestSlug,
+		TaskID:      e.TaskID,
+		TaskSlug:    e.TaskSlug,
+		DatasetID:   int(e.DatasetID.Int64),
+		Token:       e.Token,
+		Language:    e.Language.String,
+	}
+}
+
+type sqlResult struct {
+	DatasetID int `db:"dataset_id"`
+	EntryID   int `db:"entry_id"`
+	compilation
+	evaluation
+	scoring
+}
+
+func (r sqlResult) toResult() model.Result {
+	return model.Result{
+		EntryID:   r.EntryID,
+		DatasetID: r.DatasetID,
+		Compilation: model.Compilation{
+			Status:        r.compilation.Status.String,
+			Tries:         r.compilation.Tries,
+			Stdout:        r.compilation.Stdout.String,
+			Stderr:        r.compilation.Stderr.String,
+			Time:          r.compilation.Time.Float64,
+			WallClockTime: r.compilation.WallClockTime.Float64,
+			Memory:        int(r.compilation.Memory.Int64),
+		},
+		Scoring: model.Scoring{
+			TaskScore:    r.scoring.TaskScore.Float64,
+			ContestScore: r.scoring.ContestScore.Float64,
+		},
+		Evaluation: model.Evaluation{
+			Tries: r.evaluation.Tries,
+			Done:  r.evaluation.Done,
+		},
+	}
+}
+
+type sqlDraftResult struct {
+	DatasetID int `db:"dataset_id"`
+	EntryID   int `db:"entry_id"`
+	compilation
+	evaluation
+	execution
+}
+
+func (r sqlDraftResult) toDraftResult() model.DraftResult {
+	return model.DraftResult{
+		EntryID:   r.EntryID,
+		DatasetID: r.DatasetID,
+		Compilation: model.Compilation{
+			Status:        r.compilation.Status.String,
+			Tries:         r.compilation.Tries,
+			Stdout:        r.compilation.Stdout.String,
+			Stderr:        r.compilation.Stderr.String,
+			Time:          r.compilation.Time.Float64,
+			WallClockTime: r.compilation.WallClockTime.Float64,
+			Memory:        int(r.compilation.Memory.Int64),
+		},
+		Evaluation: model.Evaluation{
+			Tries: r.evaluation.Tries,
+			Done:  r.evaluation.Done,
+		},
+		Execution: model.Execution{
+			Output:        r.execution.Output,
+			Memory:        int(r.execution.Memory.Int64),
+			WallClockTime: r.execution.WallClockTime.Float64,
+			Time:          r.execution.Time.Float64,
+		},
+	}
+}
+
+type compilation struct {
+	Status        sqlCMSCompilation `db:"compilation_status"`
+	Tries         int               `db:"compilation_tries"`
+	Stdout        sql.NullString    `db:"compilation_stdout"`
+	Stderr        sql.NullString    `db:"compilation_stderr"`
+	Time          sql.NullFloat64   `db:"compilation_time"`
+	WallClockTime sql.NullFloat64   `db:"compilation_wall_clock_time"`
+	Memory        sql.NullInt64     `db:"compilation_memory"`
+}
+
+type evaluation struct {
+	Done  bool `db:"evaluation_done"`
+	Tries int  `db:"evaluation_tries"`
+}
+
+type scoring struct {
+	TaskScore    sql.NullFloat64 `db:"score"`
+	ContestScore sql.NullFloat64 `db:"public_score"`
+}
+
+type execution struct {
+	Time          sql.NullFloat64 `db:"execution_time"`
+	WallClockTime sql.NullFloat64 `db:"execution_wall_clock_time"`
+	Memory        sql.NullInt64   `db:"execution_memory"`
+	Output        []byte          `db:"output_data"`
 }
 
 type sqlCMSLanguage struct {
@@ -31,6 +142,25 @@ func (l *sqlCMSLanguage) Scan(value interface{}) error {
 
 	if !l.Valid {
 		l.String = cmsLanguageDefault
+	}
+
+	return nil
+}
+
+type sqlCMSCompilation struct {
+	sql.NullString
+}
+
+// Scan implements the Scanner interface.
+func (l *sqlCMSCompilation) Scan(value interface{}) error {
+	err := l.NullString.Scan(value)
+
+	if err != nil {
+		return err
+	}
+
+	if !l.Valid {
+		l.String = cmsCompilationStatusDefault
 	}
 
 	return nil

--- a/storage/scan.go
+++ b/storage/scan.go
@@ -1,0 +1,37 @@
+package storage
+
+import "database/sql"
+
+const (
+	cmsLanguageDefault = "none"
+)
+
+type sqlEntry struct {
+	ID          int
+	ContestID   int            `db:"contest_id"`
+	ContestSlug string         `db:"contest_slug"`
+	TaskID      int            `db:"task_id"`
+	TaskSlug    string         `db:"task_slug"`
+	DatasetID   sql.NullInt64  `db:"result_prtl_id"`
+	Language    sqlCMSLanguage `db:"language"`
+	Token       bool           `db:"token"`
+}
+
+type sqlCMSLanguage struct {
+	sql.NullString
+}
+
+// Scan implements the Scanner interface.
+func (l *sqlCMSLanguage) Scan(value interface{}) error {
+	err := l.NullString.Scan(value)
+
+	if err != nil {
+		return err
+	}
+
+	if !l.Valid {
+		l.String = cmsLanguageDefault
+	}
+
+	return nil
+}


### PR DESCRIPTION
I was wrong trying to force primitive values to handle SQL Null ones, which lead into the wrong path "trying" to work around it, but turns out you can't avoid `null`'s with Left and Right joins.